### PR TITLE
컨테이너 UID, PORT 설정할 수 있게 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - *x-mnt
       - ./docker/nginx/host.conf:/etc/nginx/conf.d/default.conf
     ports:
-      - "80:80"
+      - "${PORT:-80}:80"
   db:
     image: mariadb:10.3
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,21 @@
 version: "3.4"
 
+x-uid: &x-uid ${SUDO_UID-$UID}
+x-pwd: &x-pwd /srv
+x-mnt: &x-mnt .:/srv
+x-env: &x-env
+  DB_HOST: db
+  HOME: /srv
+  COMPOSER_HOME: /srv/.composer
+  YARN_CACHE_FOLDER: /srv/.yarn
+
 services:
   nginx:
     image: nginx:latest
     depends_on:
       - php
     volumes:
-      - .:/srv
+      - *x-mnt
       - ./docker/nginx/host.conf:/etc/nginx/conf.d/default.conf
     ports:
       - "80:80"
@@ -23,14 +32,20 @@ services:
     depends_on:
       - db
     volumes:
-      - .:/srv
-    working_dir: /srv
+      - *x-mnt
+    environment:
+      <<: *x-env
+    user: *x-uid
+    working_dir: *x-pwd
     command: ./docker/php/start
   yarn:
     image: node:8-alpine
     volumes:
-      - .:/srv
-    working_dir: /srv
+      - *x-mnt
+    environment:
+      <<: *x-env
+    user: *x-uid
+    working_dir: *x-pwd
     command: sh -c "yarn && yarn run watch"
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
 version: "3.4"
 
-x-uid: &x-uid ${SUDO_UID-$UID}
-x-pwd: &x-pwd /srv
 x-mnt: &x-mnt .:/srv
+x-pwd: &x-pwd /srv
 x-env: &x-env
   DB_HOST: db
   HOME: /srv
@@ -35,7 +34,7 @@ services:
       - *x-mnt
     environment:
       <<: *x-env
-    user: *x-uid
+    user: $UID
     working_dir: *x-pwd
     command: ./docker/php/start
   yarn:
@@ -44,7 +43,7 @@ services:
       - *x-mnt
     environment:
       <<: *x-env
-    user: *x-uid
+    user: $UID
     working_dir: *x-pwd
     command: sh -c "yarn && yarn run watch"
 


### PR DESCRIPTION
`docker-compose up` 실행 전 `UID`와 `PORT`를 `export`하면 해당 설정으로 컨테이너 실행 가능.
단, 윈도우 환경에서 `UID`는 효력이 없다.

각 변수의 의미는 다음과 같음.

- `UID`: 서버 디렉토리에 접근할 때 적용할 UID
- `PORT`: 외부 접속 시 사용할 HTTP 포트 번호